### PR TITLE
Adds support to forego waiting for both network connections and postgres connections

### DIFF
--- a/wait-for-nc.sh
+++ b/wait-for-nc.sh
@@ -22,7 +22,7 @@ USAGE
 wait_for() {
   for i in `seq $TIMEOUT` ; do
     nc -z "$HOST" "$PORT" > /dev/null 2>&1
-    
+
     result=$?
     if [ $result -eq 0 ] ; then
       if [ $# -gt 0 ] ; then
@@ -36,44 +36,51 @@ wait_for() {
   exit 1
 }
 
-while [ $# -gt 0 ]
-do
-  case "$1" in
-    *:* )
-    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
-    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
-    shift 1
-    ;;
-    -q | --quiet)
-    QUIET=1
-    shift 1
-    ;;
-    -t)
-    TIMEOUT="$2"
-    if [ "$TIMEOUT" = "" ]; then break; fi
-    shift 2
-    ;;
-    --timeout=*)
-    TIMEOUT="${1#*=}"
-    shift 1
-    ;;
-    --)
-    shift
-    break
-    ;;
-    --help)
-    usage 0
-    ;;
-    *)
-    echoerr "Unknown argument: $1"
-    usage 1
-    ;;
-  esac
-done
+if [ -z "WAIT_FOR_NC" ]; then
+  if [ "$WAIT_FOR_POSTGRES" == "true" ] ||
+     [ "$WAIT_FOR_POSTGRES" == "True" ] ||
+	 [ "$WAIT_FOR_POSTGRES" == "TRUE" ] ||
+	 [ "$WAIT_FOR_POSTGRES" == "1" ];then
+    while [ $# -gt 0 ]
+    do
+      case "$1" in
+        *:* )
+        HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+        PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [ "$TIMEOUT" = "" ]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        break
+        ;;
+        --help)
+        usage 0
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage 1
+        ;;
+      esac
+    done
 
-if [ "$HOST" = "" -o "$PORT" = "" ]; then
-  echoerr "Error: you need to provide a host and port to test."
-  usage 2
+    if [ "$HOST" = "" -o "$PORT" = "" ]; then
+      echoerr "Error: you need to provide a host and port to test."
+      usage 2
+    fi
+
+    wait_for "$@"
+  fi
 fi
-
-wait_for "$@"

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -17,10 +17,17 @@ if [[ $1 =~ $isport ]]; then
 fi
 cmd="$@"
 
-until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$host" -p "$port" -U "postgres" -c '\q'; do
-  >&2 echo "Postgres is unavailable on $host:$port - sleeping"
-  sleep 1
-done
+if [ -z "$WAIT_FOR_POSTGRES" ]; then
+  if [ "$WAIT_FOR_POSTGRES" == "true" ] ||
+     [ "$WAIT_FOR_POSTGRES" == "True" ] ||
+	 [ "$WAIT_FOR_POSTGRES" == "TRUE" ] ||
+	 [ "$WAIT_FOR_POSTGRES" == "1" ];then
+    until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$host" -p "$port" -U "postgres" -c '\q'; do
+      >&2 echo "Postgres is unavailable on $host:$port - sleeping"
+      sleep 1
+    done
+  fi
+fi
 
 >&2 echo "Postgres is available at $host:$port - proceeding"
 exec $cmd


### PR DESCRIPTION
I recognize that ordinarily one would want to make a "DONT_WAIT_FOR_POSTGRES" flag or something, to handle the rolling out of the changes a tad smoother, but "DONT_WAIT_FOR_POSTGRES" just seemed cumbersome enough on the eyes.