### PR TITLE
feat: Adds optional env variable postgres user to wait-for-postgres s…

### DIFF
--- a/Dockerfile_24
+++ b/Dockerfile_24
@@ -1,4 +1,4 @@
-# docker build -t imqs/ubuntu-base --build-arg BRANCH=18.04 .
+# docker build -t imqs/ubuntu-base --build-arg BRANCH=24.04 .
 
 ARG BRANCH=BRANCH
 FROM ubuntu:$BRANCH

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -46,10 +46,15 @@ fi
 
 cmd="$@"
 
+user="postgres"
+if [ -n "$POSTGRES_USER" ]
+    user=$POSTGRES_USER
+fi
+
 if [ -z "$WAIT_FOR_POSTGRES" ] || ([ -n "$WAIT_FOR_POSTGRES" ] &&
         ([ "$WAIT_FOR_POSTGRES" == "true" ] || [ "$WAIT_FOR_POSTGRES" == "True" ] || [ "$WAIT_FOR_POSTGRES" == "TRUE" ] || [ "$WAIT_FOR_POSTGRES" == "1" ])) ; then
   >&2 echo "WAIT_FOR_POSTGRES unset, or set to true, waiting..."
-  until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$host" -p "$port" -U "postgres" -c '\q'; do
+  until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$host" -p "$port" -U "$user" -c '\q'; do
     >&2 echo "Postgres is unavailable on $host:$port - sleeping"
     sleep 1
   done


### PR DESCRIPTION
…cript

The `wait-for-postgres.sh` script needs to have a configurable postgres user instead of always defaulting to `postgres`.

Some clients do not have the `postgres` available on their databases (DOI).

An environment variable `POSTGRES_USER` can override the user variable.

Refs: ASG-4464